### PR TITLE
feat: Add Cheatcodes::AddAccount

### DIFF
--- a/core/src/environment/instruction.rs
+++ b/core/src/environment/instruction.rs
@@ -223,6 +223,12 @@ pub enum Cheatcodes {
         /// The address of the account to fetch.
         address: ethers::types::Address,
     },
+    /// An `AddAccount` is used to add a default/unfunded account.
+    /// If the account exists, the value is updated.
+    AddAccount {
+        /// The address of the account to be added.
+        address: eAddress,
+    },
 }
 
 /// Wrapper around [`AccountState`] that can be serialized and deserialized.
@@ -263,5 +269,12 @@ pub enum CheatcodesReturn {
         account_state: AccountStateSerializable,
         /// Storage slots of the account.
         storage: HashMap<U256, U256>,
+    },
+
+    /// A `AddAccount` returns nothing.
+    AddAccount {
+        /// Basic account information of inserted account like nonce, balance,
+        /// code hash, bytcode.
+        info: AccountInfo,
     },
 }

--- a/core/src/environment/mod.rs
+++ b/core/src/environment/mod.rs
@@ -634,6 +634,15 @@ impl Environment {
         self
     }
 
+    /// Obtains the current underlying [`CacheDB`] instance
+    /// after a read lock was acquired to inspect the current execution state
+    pub fn db(&self) -> Result<CacheDB<EmptyDB>, ArbiterCoreError> {
+        match self.db.state.read() {
+            Ok(cache_db) => Ok(cache_db.clone()),
+            Err(err) => Err(ArbiterCoreError::RwLockError(err.to_string())),
+        }
+    }
+
     /// Stops the execution of the environment and returns the [`ArbiterDB`] in
     /// its final state.
     pub fn stop(mut self) -> Result<ArbiterDB, ArbiterCoreError> {

--- a/core/src/environment/mod.rs
+++ b/core/src/environment/mod.rs
@@ -366,6 +366,7 @@ impl Environment {
                         }
                         Cheatcodes::Deal { address, amount } => {
                             let recast_address = Address::from(address.as_fixed_bytes());
+
                             match db.state.write()?.accounts.get_mut(&recast_address) {
                                 Some(account) => {
                                     account.info.balance += U256::from_limbs(amount.0);
@@ -407,6 +408,23 @@ impl Environment {
                                         .send(Err(ArbiterCoreError::AccountDoesNotExistError))?;
                                 }
                             }
+                        }
+                        Cheatcodes::AddAccount { address } => {
+                            let recast_address = Address::from(address.as_fixed_bytes());
+
+                            let account = revm::db::DbAccount {
+                                info: AccountInfo::default(),
+                                account_state: AccountState::None,
+                                storage: HashMap::new(),
+                            };
+                            db.state
+                                .write()?
+                                .accounts
+                                .insert(recast_address, account.clone());
+
+                            outcome_sender.send(Ok(Outcome::CheatcodeReturn(
+                                CheatcodesReturn::AddAccount { info: account.info },
+                            )))?;
                         }
                     },
                     // A `Call` is not state changing and will not create events but will create

--- a/core/src/middleware/mod.rs
+++ b/core/src/middleware/mod.rs
@@ -426,8 +426,15 @@ impl Middleware for ArbiterMiddleware {
             Some(&to) => TransactTo::Call(to.to_fixed_bytes().into()),
             None => TransactTo::Create(CreateScheme::Create),
         };
+
+        // Extract `from` field if it exists
+        let caller = match tx.from() {
+            Some(&from) => from.to_fixed_bytes().into(),
+            None => self.address().to_fixed_bytes().into(),
+        };
+
         let tx_env = TxEnv {
-            caller: self.address().to_fixed_bytes().into(),
+            caller,
             gas_limit: u64::MAX,
             gas_price: revm::primitives::U256::from_limbs(self.get_gas_price().await?.0),
             gas_priority_fee: None,

--- a/core/tests/environment_integration.rs
+++ b/core/tests/environment_integration.rs
@@ -142,11 +142,18 @@ async fn middleware_from_forked_eo() {
 }
 
 #[tokio::test]
-async fn env_returns_db() {
+async fn env_returns_db_after_stop() {
     let (environment, client) = startup();
     deploy_arbx(client).await;
     let db = environment.stop().unwrap();
     assert!(!db.state.read().unwrap().accounts.is_empty())
+}
+
+#[tokio::test]
+async fn env_returns_db_mid_execution() {
+    let (environment, client) = startup();
+    deploy_arbx(client).await;
+    assert!(!environment.db().unwrap().accounts.is_empty())
 }
 
 #[tokio::test]

--- a/docs/src/usage/arbiter_core/environment.md
+++ b/docs/src/usage/arbiter_core/environment.md
@@ -66,6 +66,7 @@ fn main() {
 - `Instruction::Cheatcode`: Execute one of the `Cheatcodes` on the `Environment`'s world state. 
 The `Cheatcodes` include:
     - `Cheatcodes::Deal`: Used to set the raw ETH balance of a user. Useful when you need to pay gas fees in a transaction.
+    - `Cheatcodes::AddAccount`: Initializes a new default account if it doesn't exist.
     - `Cheatcodes::Load`: Gets the value of a storage slot of an account. 
     - `Cheatcodes::Store`: Sets the value of a storage slot of an account.
     - `Cheatcodes::Access`: Gets the account at an address.


### PR DESCRIPTION
**Give an overview of the tasks completed**
Arbiter currently assumes all accounts are initialized before the execution. However sometimes the user cannot anticipate all the involved accounts. With the `Cheatcodes::AddAccount` cheat code, the user can inject a new account mid execution and then update the balance with `Cheatcodes::Deal` cheat code.

The PR is based on top of #977.

**REMINDER! Please check that you have done the following prior to submitting this PR:**
- [x] Checked that the relevant version(s) have been incremented if necessary.
- [x] Ran both and made any changes necessary for:
    - `cargo +nightly fmt --all`
    - `cargo clippy --all`

